### PR TITLE
DM-53599: Ignore chunks marked as skipped during promotion

### DIFF
--- a/python/lsst/dax/ppdbx/gcp/db.py
+++ b/python/lsst/dax/ppdbx/gcp/db.py
@@ -373,6 +373,7 @@ class ReplicaChunkDatabase:
         SELECT MIN(apdb_replica_chunk) AS s
         FROM {table_name}
         WHERE status <> 'promoted'
+            AND status <> 'skipped'
         ),
         stop AS (
         SELECT MIN(p.apdb_replica_chunk) AS e
@@ -381,6 +382,7 @@ class ReplicaChunkDatabase:
         WHERE start.s IS NOT NULL
             AND p.apdb_replica_chunk >= start.s
             AND p.status <> 'staged'
+            AND status <> 'skipped'
         )
         SELECT p.apdb_replica_chunk
         FROM {table_name} p


### PR DESCRIPTION
Chunks which are skipped during export to Parquet are recorded in the database with a status of "skipped" so that they will not be reprocessed by the replication. When performing the promotion from the staging tables to prod, we need to ignore these skipped chunks so that they are not considered when finding sets of contiguous chunks to promote.